### PR TITLE
Add referral events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Savings DAI
 
 A tokenized wrapper around the DSR. Supports ERC4626. Share to asset conversions are real-time even if the pot hasn't been dripped in a while. Please note this is sample code only and there is no official deploys. Feel free to deploy it yourself.
+
+This code was created by hexonaut.
+Since it should belong to the MakerDAO community the Copyright for the code has been transferred to Dai Foundation

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Savings DAI
 
 A tokenized wrapper around the DSR. Supports ERC4626. Share to asset conversions are real-time even if the pot hasn't been dripped in a while. Please note this is sample code only and there is no official deploys. Feel free to deploy it yourself.
+
+## Referral Code
+
+The `deposit` and `mint` functions accept an optional `uint16 referral` parameter that frontends can use to mark deposits as originating from them. Such deposits emit a `Referral(uint16 indexed referral, address indexed owner, uint256 assets, uint256 shares)` event. This could be used to implement a revshare campaign, in which case the off-chain calculation scheme will likely need to keep track of any `Transfer` and `Withdraw` events following a `Referral` for a given token owner.

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,5 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+// Copyright (C) 2021-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity ^0.8.15;
 
 import "forge-std/Script.sol";

--- a/src/ISavingsDai.sol
+++ b/src/ISavingsDai.sol
@@ -1,4 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Copyright (C) 2021-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity >=0.8.0;
 
 interface ISavingsDai {

--- a/src/ISavingsDai.sol
+++ b/src/ISavingsDai.sol
@@ -29,9 +29,11 @@ interface ISavingsDai {
     function maxDeposit(address) external view returns (uint256);
     function previewDeposit(uint256) external view returns (uint256);
     function deposit(uint256, address) external returns (uint256);
+    function deposit(uint256, address, uint16) external returns (uint256);
     function maxMint(address) external view returns (uint256);
     function previewMint(uint256) external view returns (uint256);
     function mint(uint256, address) external returns (uint256);
+    function mint(uint256, address, uint16) external returns (uint256);
     function maxWithdraw(address) external view returns (uint256);
     function previewWithdraw(uint256) external view returns (uint256);
     function withdraw(uint256, address, address) external returns (uint256);

--- a/src/SavingsDai.sol
+++ b/src/SavingsDai.sol
@@ -221,19 +221,7 @@ contract SavingsDai {
 
     // --- Mint/Burn Internal ---
 
-    function _mint(uint256 shares, address receiver, uint16 referral) internal returns (uint256 assets) {
-        uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
-        assets = _divup(shares * chi, RAY);
-        _doMint(assets, shares, receiver, referral);
-    }
-
-    function _deposit(uint256 assets, address receiver, uint16 referral) internal returns (uint256 shares) {
-        uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
-        shares = assets * RAY / chi;
-        _doMint(assets, shares, receiver, referral);
-    }
-
-    function _doMint(uint256 assets, uint256 shares, address receiver, uint16 referral) internal {
+    function _mint(uint256 assets, uint256 shares, address receiver, uint16 referral) internal {
         require(receiver != address(0) && receiver != address(this), "SavingsDai/invalid-address");
 
         dai.transferFrom(msg.sender, address(this), assets);
@@ -250,7 +238,7 @@ contract SavingsDai {
         if (referral > 0) emit Referral(referral, receiver, assets, shares);
     }
 
-    function _doBurn(uint256 assets, uint256 shares, address receiver, address owner) internal {
+    function _burn(uint256 assets, uint256 shares, address receiver, address owner) internal {
         uint256 balance = balanceOf[owner];
         require(balance >= shares, "SavingsDai/insufficient-balance");
 
@@ -307,11 +295,13 @@ contract SavingsDai {
     }
 
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        shares = _deposit(assets, receiver, 0);
+        shares = deposit(assets, receiver, 0);
     }
 
-    function deposit(uint256 assets, address receiver, uint16 referral) external returns (uint256 shares) {
-        shares = _deposit(assets, receiver, referral);
+    function deposit(uint256 assets, address receiver, uint16 referral) public returns (uint256 shares) {
+        uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
+        shares = assets * RAY / chi;
+        _mint(assets, shares, receiver, referral);
     }
 
     function maxMint(address) external pure returns (uint256) {
@@ -325,11 +315,13 @@ contract SavingsDai {
     }
 
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
-        assets = _mint(shares, receiver, 0);
+        assets = mint(shares, receiver, 0);
     }
 
-    function mint(uint256 shares, address receiver, uint16 referral) external returns (uint256 assets) {
-        assets = _mint(shares, receiver, referral);
+    function mint(uint256 shares, address receiver, uint16 referral) public returns (uint256 assets) {
+        uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
+        assets = _divup(shares * chi, RAY);
+        _mint(assets, shares, receiver, referral);
     }
 
     function maxWithdraw(address owner) external view returns (uint256) {
@@ -345,7 +337,7 @@ contract SavingsDai {
     function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares) {
         uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
         shares = _divup(assets * RAY, chi);
-        _doBurn(assets, shares, receiver, owner);
+        _burn(assets, shares, receiver, owner);
     }
 
     function maxRedeem(address owner) external view returns (uint256) {
@@ -359,7 +351,7 @@ contract SavingsDai {
     function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets) {
         uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
         assets = shares * chi / RAY;
-        _doBurn(assets, shares, receiver, owner);
+        _burn(assets, shares, receiver, owner);
     }
 
     // --- Approve by signature ---
@@ -391,13 +383,13 @@ contract SavingsDai {
             abi.decode(result, (bytes4)) == IERC1271.isValidSignature.selector);
     }
 
-    function _permit(
+    function permit(
         address owner,
         address spender,
         uint256 value,
         uint256 deadline,
         bytes memory signature
-    ) internal {
+    ) public {
         require(block.timestamp <= deadline, "SavingsDai/permit-expired");
         require(owner != address(0), "SavingsDai/invalid-owner");
 
@@ -429,21 +421,11 @@ contract SavingsDai {
         address spender,
         uint256 value,
         uint256 deadline,
-        bytes memory signature
-    ) external {
-        _permit(owner, spender, value, deadline, signature);
-    }
-
-    function permit(
-        address owner,
-        address spender,
-        uint256 value,
-        uint256 deadline,
         uint8 v,
         bytes32 r,
         bytes32 s
     ) external {
-        _permit(owner, spender, value, deadline, abi.encodePacked(r, s, v));
+        permit(owner, spender, value, deadline, abi.encodePacked(r, s, v));
     }
 
 }

--- a/src/SavingsDai.sol
+++ b/src/SavingsDai.sol
@@ -221,7 +221,7 @@ contract SavingsDai {
 
     // --- Mint/Burn Internal ---
 
-    function _mint(uint256 assets, uint256 shares, address receiver, uint16 referral) internal {
+    function _mint(uint256 assets, uint256 shares, address receiver) internal {
         require(receiver != address(0) && receiver != address(this), "SavingsDai/invalid-address");
 
         dai.transferFrom(msg.sender, address(this), assets);
@@ -235,7 +235,6 @@ contract SavingsDai {
         }
 
         emit Deposit(msg.sender, receiver, assets, shares);
-        if (referral > 0) emit Referral(referral, receiver, assets, shares);
     }
 
     function _burn(uint256 assets, uint256 shares, address receiver, address owner) internal {
@@ -294,14 +293,15 @@ contract SavingsDai {
         return convertToShares(assets);
     }
 
-    function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        shares = deposit(assets, receiver, 0);
-    }
-
-    function deposit(uint256 assets, address receiver, uint16 referral) public returns (uint256 shares) {
+    function deposit(uint256 assets, address receiver) public returns (uint256 shares) {
         uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
         shares = assets * RAY / chi;
-        _mint(assets, shares, receiver, referral);
+        _mint(assets, shares, receiver);
+    }
+
+    function deposit(uint256 assets, address receiver, uint16 referral) external returns (uint256 shares) {
+        shares = deposit(assets, receiver);
+        emit Referral(referral, receiver, assets, shares);
     }
 
     function maxMint(address) external pure returns (uint256) {
@@ -314,14 +314,15 @@ contract SavingsDai {
         return _divup(shares * chi, RAY);
     }
 
-    function mint(uint256 shares, address receiver) external returns (uint256 assets) {
-        assets = mint(shares, receiver, 0);
-    }
-
-    function mint(uint256 shares, address receiver, uint16 referral) public returns (uint256 assets) {
+    function mint(uint256 shares, address receiver) public returns (uint256 assets) {
         uint256 chi = (block.timestamp > pot.rho()) ? pot.drip() : pot.chi();
         assets = _divup(shares * chi, RAY);
-        _mint(assets, shares, receiver, referral);
+        _mint(assets, shares, receiver);
+    }
+
+    function mint(uint256 shares, address receiver, uint16 referral) external returns (uint256 assets) {
+        assets = mint(shares, receiver);
+        emit Referral(referral, receiver, assets, shares);
     }
 
     function maxWithdraw(address owner) external view returns (uint256) {

--- a/src/test/SavingsDai-erc4626.t.sol
+++ b/src/test/SavingsDai-erc4626.t.sol
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: AGPL-3.0
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Copyright (C) 2021-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pragma solidity ^0.8.17;
 

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -38,7 +38,7 @@ contract MockMultisig is IERC1271 {
     }
 }
 
-contract SavingsDaiIntegrationTest is DSSTest {
+contract SavingsDaiIntegrationTest is DssTest {
 
     using GodMode for *;
 
@@ -58,7 +58,7 @@ contract SavingsDaiIntegrationTest is DSSTest {
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
-    function setUp() public override {
+    function setUp() public {
         ChainlogAbstract chainlog = ChainlogAbstract(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
         
         vat = VatAbstract(chainlog.getAddress("MCD_VAT"));

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -53,7 +53,7 @@ contract SavingsDaiIntegrationTest is DSSTest {
     event Approval(address indexed owner, address indexed spender, uint256 amount);
     event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
     event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares);
-    event ReferredDeposit(uint16 indexed referralCode, uint256 assets, uint256 shares);
+    event ReferredDeposit(uint16 indexed referralCode, address indexed owner, uint256 assets, uint256 shares);
 
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
@@ -134,7 +134,7 @@ contract SavingsDaiIntegrationTest is DSSTest {
         vm.expectEmit(true, true, true, true);
         emit Deposit(address(this), address(0xBEEF), 1e18, pie);
         vm.expectEmit(true, true, true, true);
-        emit ReferredDeposit(888, 1e18, pie);
+        emit ReferredDeposit(888, address(0xBEEF), 1e18, pie);
         token.deposit(1e18, address(0xBEEF), 888);
 
         assertEq(token.totalSupply(), pie);
@@ -173,7 +173,7 @@ contract SavingsDaiIntegrationTest is DSSTest {
         vm.expectEmit(true, true, true, true);
         emit Deposit(address(this), address(0xBEEF), _divup(pie * pot.chi(), RAY), pie);
         vm.expectEmit(true, true, true, true);
-        emit ReferredDeposit(888, 1e18, pie);
+        emit ReferredDeposit(888, address(0xBEEF), 1e18, pie);
         token.mint(pie, address(0xBEEF), 888);
 
         assertEq(token.totalSupply(), pie);

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -127,7 +127,7 @@ contract SavingsDaiIntegrationTest is DssTest {
         assertEq(vat.dai(address(pot)), dsrDai + pie * pot.chi());
     }
 
-    function testReferral() public {
+    function testReferredDeposit() public {
         uint256 dsrDai = vat.dai(address(pot));
 
         uint256 pie = 1e18 * RAY / pot.chi();

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -766,7 +766,7 @@ contract SavingsDaiIntegrationTest is DssTest {
         if (to == address(0) || to == address(token)) return;
 
         uint256 pie = mintAmount * RAY / pot.chi();
-        burnAmount = bound(burnAmount, pie + 1, type(uint256).max);
+        burnAmount = bound(burnAmount, pie + 1, type(uint256).max / pot.chi());
 
         token.deposit(mintAmount, to);
         vm.expectRevert("SavingsDai/insufficient-balance");

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -1,5 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+// Copyright (C) 2021-2022 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity ^0.8.17;
 
 import "dss-test/DssTest.sol";

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -616,6 +616,9 @@ contract SavingsDaiIntegrationTest is DssTest {
         vm.warp(block.timestamp + warp % 365 days);
         if (from == address(0) || from == address(token)) return;
 
+        uint256 initialFromBalance = dai.balanceOf(from);
+        uint256 initialTestBalance = dai.balanceOf(TEST_ADDRESS);
+
         uint256 pie = token.convertToShares(mintAmount);
         burnAmount = bound(burnAmount, 0, pie);
 
@@ -628,8 +631,8 @@ contract SavingsDaiIntegrationTest is DssTest {
         uint256 aassets = token.redeem(burnAmount, TEST_ADDRESS, from);
 
         assertEq(aassets, assets);
-        if (from != TEST_ADDRESS) assertEq(dai.balanceOf(from), 0);
-        assertEq(dai.balanceOf(TEST_ADDRESS), assets);
+        if (from != TEST_ADDRESS) assertEq(dai.balanceOf(from), initialFromBalance);
+        assertEq(dai.balanceOf(TEST_ADDRESS), initialTestBalance + assets);
     }
 
     function testWithdraw(
@@ -643,6 +646,9 @@ contract SavingsDaiIntegrationTest is DssTest {
         vm.warp(block.timestamp + warp % 365 days);
         if (from == address(0) || from == address(token)) return;
 
+        uint256 initialFromBalance = dai.balanceOf(from);
+        uint256 initialTestBalance = dai.balanceOf(TEST_ADDRESS);
+
         uint256 pie = token.convertToShares(mintAmount);
         burnAmount = bound(burnAmount, 0, mintAmount);
 
@@ -655,8 +661,8 @@ contract SavingsDaiIntegrationTest is DssTest {
         uint256 ashares = token.withdraw(burnAmount, TEST_ADDRESS, from);
 
         assertEq(ashares, shares);
-        if (from != TEST_ADDRESS) assertEq(dai.balanceOf(from), 0);
-        assertEq(dai.balanceOf(TEST_ADDRESS), burnAmount);
+        if (from != TEST_ADDRESS) assertEq(dai.balanceOf(from), initialFromBalance);
+        assertEq(dai.balanceOf(TEST_ADDRESS), initialTestBalance + burnAmount);
         assertEq(token.totalSupply(), pie - shares);
         assertEq(token.balanceOf(from), pie - shares);
     }

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -527,7 +527,7 @@ contract SavingsDaiIntegrationTest is DssTest {
     function testPermitPastDeadline() public {
         uint256 privateKey = 0xBEEF;
         address owner = vm.addr(privateKey);
-        uint256 deadline = block.timestamp == 0 ? 0 : block.timestamp - 1;
+        uint256 deadline = block.timestamp;
 
         bytes32 domain_separator = token.DOMAIN_SEPARATOR();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(
@@ -545,6 +545,11 @@ contract SavingsDaiIntegrationTest is DssTest {
 
         vm.expectRevert("SavingsDai/permit-expired");
         token.permit(owner, address(0xCAFE), 1e18, deadline, v, r, s);
+    }
+
+    function testPermitOwnerZero() public {
+        vm.expectRevert("SavingsDai/invalid-owner");
+        token.permit(address(0), address(0xCAFE), 1e18, block.timestamp, 28, bytes32(0), bytes32(0));
     }
 
     function testPermitReplay() public {
@@ -906,7 +911,6 @@ contract SavingsDaiIntegrationTest is DssTest {
         uint256 deadline
     ) public {
         if (deadline == type(uint256).max) deadline -= 1;
-        vm.warp(deadline);
 
         // private key cannot be 0 for secp256k1 pubkey generation
         if (privateKey == 0) privateKey = 1;

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -54,8 +54,7 @@ contract SavingsDaiIntegrationTest is DSSTest {
     event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
     event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares);
     event ReferredDeposit(uint16 indexed referralCode, uint256 assets, uint256 shares);
-    event ReferredWithdraw(uint16 indexed referralCode, uint256 assets, uint256 shares);
-    
+
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
@@ -209,26 +208,6 @@ contract SavingsDaiIntegrationTest is DSSTest {
         assertEq(vat.dai(address(pot)), dsrDai + pie * pot.chi() - (pie * 0.9e18 / WAD) * pot.chi());
     }
 
-    function testReferredRedeem() public {
-        uint256 dsrDai = vat.dai(address(pot));
-
-        token.deposit(1e18, address(0xBEEF));
-        uint256 pie = 1e18 * RAY / pot.chi();
-
-        assertEq(vat.dai(address(pot)), dsrDai + pie * pot.chi());
-
-        vm.expectEmit(true, true, true, true);
-        emit Withdraw(address(0xBEEF), address(this), address(0xBEEF), (pie * 0.9e18 / WAD) * pot.chi() / RAY, pie * 0.9e18 / WAD);
-        vm.expectEmit(true, true, true, true);
-        emit ReferredWithdraw(888, (pie * 0.9e18 / WAD) * pot.chi() / RAY, pie * 0.9e18 / WAD);
-        vm.prank(address(0xBEEF));
-        token.redeem(pie * 0.9e18 / WAD, address(this), address(0xBEEF), 888);
-
-        assertEq(token.totalSupply(), pie - pie * 0.9e18 / WAD);
-        assertEq(token.balanceOf(address(0xBEEF)), pie - pie * 0.9e18 / WAD);
-        assertEq(vat.dai(address(pot)), dsrDai + pie * pot.chi() - (pie * 0.9e18 / WAD) * pot.chi());
-    }
-
     function testWithdraw() public {
         uint256 dsrDai = vat.dai(address(pot));
 
@@ -243,28 +222,6 @@ contract SavingsDaiIntegrationTest is DSSTest {
         emit Withdraw(address(0xBEEF), address(this), address(0xBEEF), assets, shares);
         vm.prank(address(0xBEEF));
         token.withdraw(assets, address(this), address(0xBEEF));
-
-        assertEq(token.totalSupply(), pie - shares);
-        assertEq(token.balanceOf(address(0xBEEF)), pie - shares);
-        assertEq(vat.dai(address(pot)), dsrDai + pie * pot.chi() - shares * pot.chi());
-    }
-
-    function testReferredWithdraw() public {
-        uint256 dsrDai = vat.dai(address(pot));
-
-        token.deposit(1e18, address(0xBEEF));
-        uint256 pie = 1e18 * RAY / pot.chi();
-
-        assertEq(vat.dai(address(pot)), dsrDai + pie * pot.chi());
-
-        uint256 assets = (pie * 0.9e18 / WAD) * pot.chi() / RAY;
-        uint256 shares = _divup(assets * RAY, pot.chi());
-        vm.expectEmit(true, true, true, true);
-        emit Withdraw(address(0xBEEF), address(this), address(0xBEEF), assets, shares);
-        vm.expectEmit(true, true, true, true);
-        emit ReferredWithdraw(888, assets, shares);
-        vm.prank(address(0xBEEF));
-        token.withdraw(assets, address(this), address(0xBEEF), 888);
 
         assertEq(token.totalSupply(), pie - shares);
         assertEq(token.balanceOf(address(0xBEEF)), pie - shares);

--- a/src/test/SavingsDai-integration.t.sol
+++ b/src/test/SavingsDai-integration.t.sol
@@ -53,7 +53,7 @@ contract SavingsDaiIntegrationTest is DSSTest {
     event Approval(address indexed owner, address indexed spender, uint256 amount);
     event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
     event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares);
-    event ReferredDeposit(uint16 indexed referralCode, address indexed owner, uint256 assets, uint256 shares);
+    event Referral(uint16 indexed referral, address indexed owner, uint256 assets, uint256 shares);
 
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
@@ -127,14 +127,14 @@ contract SavingsDaiIntegrationTest is DSSTest {
         assertEq(vat.dai(address(pot)), dsrDai + pie * pot.chi());
     }
 
-    function testReferredDeposit() public {
+    function testReferral() public {
         uint256 dsrDai = vat.dai(address(pot));
 
         uint256 pie = 1e18 * RAY / pot.chi();
         vm.expectEmit(true, true, true, true);
         emit Deposit(address(this), address(0xBEEF), 1e18, pie);
         vm.expectEmit(true, true, true, true);
-        emit ReferredDeposit(888, address(0xBEEF), 1e18, pie);
+        emit Referral(888, address(0xBEEF), 1e18, pie);
         token.deposit(1e18, address(0xBEEF), 888);
 
         assertEq(token.totalSupply(), pie);
@@ -173,7 +173,7 @@ contract SavingsDaiIntegrationTest is DSSTest {
         vm.expectEmit(true, true, true, true);
         emit Deposit(address(this), address(0xBEEF), _divup(pie * pot.chi(), RAY), pie);
         vm.expectEmit(true, true, true, true);
-        emit ReferredDeposit(888, address(0xBEEF), 1e18, pie);
+        emit Referral(888, address(0xBEEF), 1e18, pie);
         token.mint(pie, address(0xBEEF), 888);
 
         assertEq(token.totalSupply(), pie);

--- a/src/test/mocks/VatMock.sol
+++ b/src/test/mocks/VatMock.sol
@@ -3,6 +3,7 @@
 /// vat.sol -- Dai CDP database
 
 // Copyright (C) 2018 Rain <rainbreak@riseup.net>
+// Copyright (C) 2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
Note that `referral` is not included as an optional parameter to the `withdraw`/`redeem` functions. Doing so would lead to the following issues:

- Frontends would need to be trusted to correctly pass `referral` to `withdraw`/`redeem` functions. They may have a financial incentive to not do so if rewards are calculated based on how long DAI is deposited for. Worse, they may choose to maliciously pass the `referral` of another frontend in `withdraw`/`redeem` if the reward scheme is based on a pre-defined total promotional budget.

- Frontends would need to handle the special case of users depositing via frontend A and withdrawing via frontend B which makes frontend implementation more complex and error prone.

Instead we assume that the calculation scheme will keep track of any `Transfer` and `Withdraw` events following a referred `Deposit` for a given token owner.